### PR TITLE
Fix: made pathogen installation method really functionnal

### DIFF
--- a/plugin/debugger.vim
+++ b/plugin/debugger.vim
@@ -4,7 +4,7 @@
 "=============================================================================
 "    Copyright: Copyright (C) 2007 Sam Ghods
 "      License:	The MIT License
-"				
+"
 "				Permission is hereby granted, free of charge, to any person obtaining
 "				a copy of this software and associated documentation files
 "				(the "Software"), to deal in the Software without restriction,
@@ -12,10 +12,10 @@
 "				merge, publish, distribute, sublicense, and/or sell copies of the
 "				Software, and to permit persons to whom the Software is furnished
 "				to do so, subject to the following conditions:
-"				
+"
 "				The above copyright notice and this permission notice shall be included
 "				in all copies or substantial portions of the Software.
-"				
+"
 "				THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 "				OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 "				MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -39,7 +39,7 @@
 "
 "               This file should reside in the plugins directory along
 "               with debugger.py and be automatically sourced.
-"               
+"
 "               By default, the script expects the debugging engine to connect
 "               on port 9000. You can change this with the g:debuggerPort
 "               variable by putting the following line your vimrc:
@@ -91,7 +91,7 @@
 "                     o Added support for minibufexpl.vim.
 "                     o License added.
 "               1.0   o Initial release on December 7, 2004
-"      
+"
 " Known Issues: The code is designed for the DBGp protocol, but it has only been
 " 				tested with XDebug 2.0RC4. If anyone would like to contribute patches
 " 				to get it working with other DBGp software, I would be happy
@@ -102,7 +102,7 @@
 " 				so on... if you can actually find a set of solidly
 " 				reproducible steps that lead to a bug, please do e-mail <sam
 " 				<at> box.net> and I will take a look.
-" 
+"
 "         Todo: Compatibility for other DBGp engines.
 "
 "         		Add a status line/window which constantly shows what the current
@@ -124,7 +124,14 @@ if filereadable($VIMRUNTIME."/plugin/debugger.py")
 elseif filereadable($HOME."/.vim/plugin/debugger.py")
   pyfile $HOME/.vim/plugin/debugger.py
 else
-  call confirm('debugger.vim: Unable to find debugger.py. Place it in either your home vim directory or in the Vim runtime directory.', 'OK')
+  " when we use pathogen for instance
+  let $CUR_DIRECTORY=expand("<sfile>:p:h")
+
+  if filereadable($CUR_DIRECTORY."/debugger.py")
+    pyfile $CUR_DIRECTORY/debugger.py
+  else
+    call confirm('debugger.vim: Unable to find debugger.py. Place it in either your home vim directory or in the Vim runtime directory.', 'OK')
+  endif
 endif
 
 map <F1> :python debugger_resize()<cr>
@@ -162,7 +169,7 @@ sign define breakpt text=B>  texthl=DbgBreakPt linehl=DbgBreakPt
 
 if !exists('g:debuggerPort')
   let g:debuggerPort = 9000
-endif 
+endif
 if !exists('g:debuggerMaxChildren')
   let g:debuggerMaxChildren = 32
 endif


### PR DESCRIPTION
Using this plugin with pathogen was not possible, due to the way the debugger.py file was included (it was never found by the script).

I fixed that by checking the current path.
